### PR TITLE
fix: Allow legacy ".yml" extension for kustomize-file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+coverage.out

--- a/argocd.go
+++ b/argocd.go
@@ -125,7 +125,7 @@ func listArgoCDDeployments() error {
 			fmt.Println("Found helm deployment with name: " + trackedDeployment.Metadata.Name)
 			fmt.Println("  path: " + trackedDeployment.Spec.Source.Path)
 			fmt.Println("  valueFiles: " + strings.Join(trackedDeployment.Spec.Source.Helm.ValueFiles, ", "))
-		} else if _, err := os.Stat(trackedDeployment.Spec.Source.Path + "/kustomization.yaml"); err == nil {
+		} else if isKustomizeDir(trackedDeployment.Spec.Source.Path) {
 			fmt.Println("---")
 			fmt.Println("Found kustomize deployment with name: " + trackedDeployment.Metadata.Name)
 			fmt.Println("  path: " + trackedDeployment.Spec.Source.Path)

--- a/template.go
+++ b/template.go
@@ -13,7 +13,7 @@ import (
 func renderTemplate(app ArgoCDApp) (string, error) {
 	if app.Spec.Source.Helm.ReleaseName != "" {
 		return renderHelm(app.Spec.Source)
-	} else if _, err := os.Stat(app.Spec.Source.Path + "/kustomization.yaml"); err == nil {
+	} else if isKustomizeDir(app.Spec.Source.Path) {
 		return renderKustomize(app.Spec.Source.Path)
 	}
 	return app.Spec.Source.Path, nil

--- a/utils.go
+++ b/utils.go
@@ -26,3 +26,14 @@ func tempDir() (string, error) {
 	}
 	return dir, nil
 }
+
+func isKustomizeDir(dirPath string) bool {
+	if _, err := os.Stat(dirPath + "/kustomization.yaml"); err == nil {
+		return true
+	}
+	// Support legacy .yml extension
+	if _, err := os.Stat(dirPath + "/kustomization.yml"); err == nil {
+		return true
+	}
+	return false
+}


### PR DESCRIPTION
The extension is only used to detect if the kustomization-file exists. The rest is offloaded to the "kustomize" CLI tool, which accepts a directory, and can work with both "yml" and "yaml" files
