### PR TITLE
feat: dont render helm tests

### DIFF
--- a/template.go
+++ b/template.go
@@ -44,6 +44,7 @@ func renderHelm(source ArgoCDAppSource) (string, error) {
 		return "", err
 	}
 	err = sh.Run("helm", "template",
+		"--skip-tests",
 		"-f", strings.Join(source.Helm.ValueFiles, ","),
 		"--output-dir", dir,
 		".")


### PR DESCRIPTION
helm files with the hook: test are ignored by argocd ref:
https://argo-cd.readthedocs.io/en/stable/user-guide/helm/#helm-skip-tests

Some upstream helm charts have tests but they dont have a lot of
configuration. Currenty they are validated by the linters and thus fail.
This will help with using more upstream helm charts
