### PR TITLE
feat: dont error when the helm directory is not found

### DIFF
--- a/template.go
+++ b/template.go
@@ -30,7 +30,12 @@ func renderHelm(source ArgoCDAppSource) (string, error) {
 	}
 	err = os.Chdir(source.Path)
 	if err != nil {
-		return "", err
+		// dont error here, it seems we cannot
+		// find the directory so we dont render templates
+		// cause could be wrong configuration of the argocd app
+		// or the new config is not yet on the main branch
+		fmt.Printf("Directory %s not found. Skipping rendering manifests.\n", source.Path)
+		return "", nil
 	}
 	// temporary fix  until https://github.com/helm/helm/issues/7214 is fixed
 	// again


### PR DESCRIPTION
Not error out will have a better behavior. The lib retrieves the directory from the ArgoCD app in argocd, which is controlled by definitions defined in `coopnorge/kubernetes-projects`

If there is a directory configured which does not exist due to a mistake or due to it not yet being on the main branch then it is blocking if we error here.
If a user makes a mistake on configuring the directory then the only harm is that there are no manifests synced. We prefer to not block in this case. 