### PR TITLE
chore: Point to the quay for argocd image

### DIFF
--- a/docker-compose/Dockerfile
+++ b/docker-compose/Dockerfile
@@ -1,5 +1,4 @@
-
-FROM docker.io/argoproj/argocd:v2.6.15@sha256:58ebb4ed23c8db4cd4cc3f954f8d94c4b4e3d9669c0751c484108d22b86d52de as argocd
+FROM quay.io/argoproj/argocd:v2.11.13@sha256:b7c5c16c606219bde88a9c3d990aa4b34ec7d1d04dc32de05384cacd8c8a1adf AS argocd
 FROM zegl/kube-score:v1.20.0@sha256:ac4c43ad560af905d66f6bf57b0937c591332e6dbf2167c31193a13b4695ab97 as kube-score
 FROM ghcr.io/yannh/kubeconform:v0.7.0@sha256:85dbef6b4b312b99133decc9c6fc9495e9fc5f92293d4ff3b7e1b30f5611823c as kubeconform
 FROM ghcr.io/kyverno/kyverno-cli:v1.14.4@sha256:bcc4db143edb795cb6a20b111b60368925a9b2ebdc66284afe748c3f7c27dab4 AS kyverno


### PR DESCRIPTION
ArgoCD moved to quay some time ago: argo-cd.readthedocs.io/en/stable/operator-manual/upgrading/1.8-2.0#container-registry-switched-to-quayio-and-sundown-of-docker-hub-repository

ref: https://github.com/coopnorge/cloud-platform-team/issues/1058