### PR TITLE
fix: Skip apps with empty path

### DIFF
--- a/template.go
+++ b/template.go
@@ -99,6 +99,10 @@ func renderTemplates() (string, error) {
 			return "", fmt.Errorf("rendering templates failed for %s: %w", trackedDeployment, err)
 		}
 		fmt.Println("listing files in templates directory: " + templates)
+		if templates == "" {
+			fmt.Println("templates is empty. Skipping listing files.")
+			continue
+		}
 		tackedFiles, err := listFilesInDirectory(templates)
 		if err != nil {
 			return "", fmt.Errorf("listing files failed for %s: %w", trackedDeployment, err)


### PR DESCRIPTION
This fix simply skips processing apps that don't have a path defined:

> Preparing to render template for app: istio-api-platform-production
> Rendering template
> listing files in templates directory:
> templates is empty. Skipping listing files.
> Preparing to render template for app: istio-api-platform-staging
> Rendering template
> listing files in templates directory:
> templates is empty. Skipping listing files.
> Preparing to render template for app: kubernetes-base
> Rendering helm release kubernetes-base
> rendering helm templates to: /tmp/kubernetes-validation-498305131
> listing files in templates directory: /tmp/kubernetes-validation-498305131
> Preparing to render template for app: kubernetes-external-secrets-api-platform-production
> Rendering template
> listing files in templates directory:
> templates is empty. Skipping listing files.
> Preparing to render template for app: kubernetes-external-secrets-api-platform-staging
> Rendering template
> listing files in templates directory:
> templates is empty. Skipping listing files.
> Preparing to render template for app: kyverno-policies-api-platform-production
> Rendering template
> listing files in templates directory:
> templates is empty. Skipping listing files.
> Preparing to render template for app: kyverno-policies-api-platform-staging
> Rendering template
> listing files in templates directory:
> templates is empty. Skipping listing files.
> Preparing to render template for app: pod-security-policy-management-production
> Rendering template
> listing files in templates directory:
> templates is empty. Skipping listing files.


ref: https://github.com/coopnorge/cloud-platform-team/issues/1102