### PR TITLE
feat: Add support for setting values

### DIFF
--- a/argocd.go
+++ b/argocd.go
@@ -13,6 +13,7 @@ import (
 type ArgoCDAppHelm struct {
 	ReleaseName string   `yaml:"releaseName"`
 	ValueFiles  []string `yaml:"valueFiles"`
+	Values      string   `yaml:"values"`
 }
 
 // ArgoCDAppSource contains the info where to find the source for rendering


### PR DESCRIPTION
Currently, only `helm.valueFiles` are supported when rendering templates. This will add support for `helm.values`.